### PR TITLE
Ausgabe einer Karte in der Auskunft

### DIFF
--- a/conf/alkisn_conf.php
+++ b/conf/alkisn_conf.php
@@ -7,6 +7,7 @@
 	2020-12-16 Sonderfall QWC2 API-Gateway-Umleitung bei Selbstverlinkung
 	2021-12-07 Neue Parameter $katAmtMix (Kataster-Amt-Mix) und $fsHistorie
 	2021-12-09 Neuer Parameter $PrntBtn (Drucken-Schaltfläche)
+	2026-06-15 Neue Parameter §mapConfig zur Generierung einer Karte via getMap-Request (siehe auch getMapImage($config) in alkisfkt.php)
 */
 
 //	Default Bundesland-Schlüssel, falls dieser bei Anfragen ausgelassen wird
@@ -90,4 +91,23 @@
 //		log_line_prefix = '%t [%a-%h] %q%u@%d '
 //	wobei %a = Application
 
+
+// Ausgabe einer Karte via Flurstücksauskunft
+// beim Aufruf der Skripte alkisfsnw.php bzw alkisausk.php muss die BBOX komma-separiert übergeben werden
+// der GetMap-Request wird zusammengestellt und an den definierten WMS gesendet (siehe map_url, map_layers)
+// Die Breite (map_image_width) und Höhe (map_image_height) des Kartenbildes kann definiert werden.
+// Außerdem kann ein Buffer (map_buffer) definiert werden, der bei der Anfrage verwendet wird.
+// Soll keine Karte angezeigt werden, kann entweder 'activate_map' in der Konfiguration auf false gesetzt werden
+// oder beim Aufruf der PHP-Skripte &map=false übergeben werden.
+// das Highlighting des betreffenden Flurstücks erfolgt über den Dienst.
+
+    $mapConfig = [
+        'activate_map' => false,  // false default
+        'map_url' => 'https://www.wms.nrw.de/geobasis/wms_nw_alkis?',
+        'map_layers' => 'adv_alkis_flurstuecke', // oder kommasepariert: 'flurstuecke,gebäude';
+        'map_epsg' => 'EPSG:25832',
+        'map_image_width' => 700,
+        'map_image_height' => 500,
+        'map_buffer' => 100,
+    ];
 ?>

--- a/info/alkisn/alkisausk.php
+++ b/info/alkisn/alkisausk.php
@@ -17,6 +17,7 @@
 	2020-12-15 Input-Validation und Strict Comparisation (===)
 	2022-01-13 Neue Functions LnkStf(), DsKy()
 	2022-07-05 PHP 8.1: Connection verwenden bei "pg_prepare" und "pg_execute", keine NULL-Werte in String-Functions verwenden
+	2026-06-15 Generierung einer Karte via getMap-Request (siehe auch getMapImage($config) in alkisfkt.php und neuem Parameter §mapConfig in der alkisn_config.php)    
 
 H i n w e i s :  Dies Modul wird beim Entwickler nicht mehr produktiv eingesetzt.
 		Statt dessen wird "alkisinlayausk.php" verwendet um von einer WMS-FeatureInfo in ein Fenster überzuleiten.
@@ -116,7 +117,7 @@ echo "\n<table class='outer'>\n<tr>\n<td>"
 ."\n\t<p class='nwlink'>weitere Auskunft:<br>";
 
 // Flurstücksnachweis (o. Eigent.)
-echo "\n\t<a href='alkisfsnw.php?gkz=".$gkz."&amp;gmlid=".$gmlid."&amp;eig=n".LnkStf()
+echo "\n\t<a href='alkisfsnw.php?gkz=".$gkz."&amp;gmlid=".$gmlid."&amp;bbox=".$bbox."&amp;eig=n".LnkStf()
 	."' title='Flurst&uuml;cksnachweis, alle Flurst&uuml;cksdaten'>Flurst&uuml;ck "
 	."<img src='ico/Flurstueck_Link.png' width='16' height='16' alt=''>"
 ."</a><br>";
@@ -245,8 +246,17 @@ while($rowg = pg_fetch_array($resg)) {
 	$j++;
 }
 if ($j === 0) {echo "\n<p class='err'>Keine Buchungen gefunden.</p>";}
-echo "\n<hr>";
 
+
+// Karte zum FS
+if ((!isset($map) || $map !== 'false') && $mapConfig['activate_map'] !== false) {
+    $mapConfig['bbox'] = $bbox;
+    $mapConfig['gml_id'] = $gmlid;
+    $image = getMapImage($mapConfig);
+    echo "\n<hr>\n<div><img src='" . $image . "' /></div>\n";
+}
+
+echo "\n<hr>";
 footer($gmlid, selbstverlinkung()."?", "");
 
 ?>

--- a/info/alkisn/alkisfkt.php
+++ b/info/alkisn/alkisfkt.php
@@ -18,6 +18,7 @@
 	2021-12-30 Bestandsnachweis recursiv über alle Buchungs-Ebenen
 	2022-01-13 Functions in Fach-Modul verschoben, wenn nur von einem verwendet. Neue Functions LnkStf(), DsKy()
 	2022-07-05 PHP 8.1: Connection verwenden bei "pg_prepare" und "pg_execute", keine NULL-Werte in String-Functions verwenden
+        2026-06-15 Funktion getMapImage($config) generiert einen getMap-Request
 */
 
 function selbstverlinkung() {
@@ -658,5 +659,56 @@ function fskenn_dbformat($fskennz) {
 		$fskzdb=$land.$zgemkg.$zflur.$zzaehler.$znenner.'__'; // FS-Kennz. Format Datenbank
 	}
 	return $fskzdb;
+}
+
+function getMapImage($config) {
+    $bbox = $config['bbox'];
+    if (!empty($config['map_buffer'])) {
+        $buf = floatval($config['map_buffer']);
+        list($xmin,$ymin,$xmax,$ymax) =
+            array_map('floatval', explode(',', $bbox));
+        $xmin -= $buf;
+        $ymin -= $buf;
+        $xmax += $buf;
+        $ymax += $buf;
+        $img_ratio =
+            $config['map_image_width']
+            / $config['map_image_height'];
+        $bbox_width  = $xmax - $xmin;
+        $bbox_height = $ymax - $ymin;
+        $bbox_ratio = $bbox_width / $bbox_height;
+        if ($bbox_ratio > $img_ratio) {
+
+  // Karte zu breit → Höhe erweitern 
+            $target_height = $bbox_width / $img_ratio;
+            $delta =
+                ($target_height - $bbox_height) / 2;
+            $ymin -= $delta;
+            $ymax += $delta;
+        } else {
+  // Karte zu hoch → Breite erweitern 
+            $target_width =
+                $bbox_height * $img_ratio;
+            $delta =
+                ($target_width - $bbox_width) / 2;
+            $xmin -= $delta;
+            $xmax += $delta;
+        }
+        $bbox =
+            "$xmin,$ymin,$xmax,$ymax";
+    }
+    return
+        $config['map_url']
+        . 'SERVICE=WMS'
+        . '&VERSION=1.3.0'
+        . '&REQUEST=GetMap'
+        . '&BBOX=' . $bbox
+        . '&LAYERS=' . $config['map_layers']
+        . '&WIDTH=' . $config['map_image_width']
+        . '&HEIGHT=' . $config['map_image_height']
+        . '&CRS=' . $config['map_epsg']
+        . '&FORMAT=image/png'
+        . '&STYLES='
+        . '&gml_id=' . $config['gml_id'];
 }
 ?>

--- a/info/alkisn/alkisfsnw.php
+++ b/info/alkisn/alkisfsnw.php
@@ -16,6 +16,7 @@
 	2021-12-09 Neue Parameter: $katAmtMix (Kataster-Amt-Mix), $PrntBtn (Drucken-Schaltfläche)
 	2022-01-13 Functions in Fach-Modul verschoben, die nicht von mehreren verwendet werden. Neue Functions LnkStf(), DsKy()
 	2022-07-05 PHP 8.1: Connection verwenden bei "pg_prepare" und "pg_execute", keine NULL-Werte in String-Functions verwenden
+	2026-06-15 Generierung einer Karte via getMap-Request (siehe auch getMapImage($config) in alkisfkt.php und neuem Parameter §mapConfig in der alkisn_config.php)  
 
 ToDo:
 	- Tabbelle "nutz_21" ist ein Relikt von NorGIS/ALB und könnte in späteren Versionen fehlen.
@@ -671,6 +672,15 @@ if ($gml_buchungsstelle === '') {
 }
 
 pg_close($con);
+
+// Karte zum FS
+if ((!isset($map) || $map !== 'false') && $mapConfig['activate_map'] !== false) {
+    $mapConfig['bbox'] = $bbox;
+    $mapConfig['gml_id'] = $gmlid;
+    $image = getMapImage($mapConfig);
+    echo "\n<hr>\n<div><img src='" . $image . "' /></div>\n";
+}
+
 echo "<div class='buttonbereich noprint'>\n<hr>"
 	."\n\t<a title='zur&uuml;ck' href='javascript:history.back()'><img src='ico/zurueck.png' width='16' height='16' alt='zur&uuml;ck'></a>&nbsp;";
 if ($PrntBtn==true){echo "\n\t<a title='Drucken' href='javascript:window.print()'><img src='ico/print.png' width='16' height='16' alt='Drucken'></a>&nbsp;";}


### PR DESCRIPTION
### Erweitertes Feature Ausgabe Karte
- Gibt eine Karte aus (via getMap-Request)
- in der Konfiguration kann definiert werden, ob eine Karte gewünscht ist
- via map=false kann beim Aufruf der Skript die Karte auf deaktiviert werden
- Das Hervorheben des Flurstücks kann via WMS erfolgen. Hierbei wird die gmlid an den WMS übergeben. 

Beispiel MapServer: Via Vendor specific wird im Layer gff das übergebene Flurstück hervorgehoben

```
LAYER NAME "gff" 
...
	VALIDATION
		'default_gml_id' 'DENW36AL10007EGE'
		'gml_id' '.'
	END	

        CLASSITEM "gml_id"

		CLASS
			#NAME "Auswahl"
			EXPRESSION '%gml_id%'

			STYLE
				LINECAP SQUARE LINEJOIN ROUND
				OUTLINECOLOR 255 0 0
				SIZE 02.85 WIDTH 2.85
			END
		END
...
```

Beim Aufruf der php-Skripte muss die BBOX übergeben werden. Dies kann beim MapServer erfolgen über:

` '&bbox='+'[shpminx]' +','+ '[shpminy]' +','+ '[shpmaxx]' +','+ '[shpmaxy]' `


<img width="753" height="907" alt="alkis_mit_karte" src="https://github.com/user-attachments/assets/75a488ee-6ed6-434b-92ea-b9f5d3e88755" />

